### PR TITLE
Finish removing extraneous `requestFrom(int, int, int)` calls

### DIFF
--- a/src/MPU6050_tockn.cpp
+++ b/src/MPU6050_tockn.cpp
@@ -67,7 +67,7 @@ void MPU6050::calcGyroOffsets(bool console, uint16_t delayBefore, uint16_t delay
     wire->beginTransmission(MPU6050_ADDR);
     wire->write(0x43);
     wire->endTransmission(false);
-    wire->requestFrom((int)MPU6050_ADDR, 6, (int)true);
+    wire->requestFrom((int)MPU6050_ADDR, 6);
 
     rx = wire->read() << 8 | wire->read();
     ry = wire->read() << 8 | wire->read();


### PR DESCRIPTION
@tockn, this is a follow up to [this PR](https://github.com/tockn/MPU6050_tockn/pull/20). I didn't realize I missed a location. Same change, same purpose.