### PR TITLE
Updated header to use forward declaration for TwoWire and moved wire.h to .cpp file

### DIFF
--- a/src/MPU6050_tockn.cpp
+++ b/src/MPU6050_tockn.cpp
@@ -1,5 +1,6 @@
 #include "MPU6050_tockn.h"
 #include "Arduino.h"
+#include "Wire.h"
 
 MPU6050::MPU6050(TwoWire &w){
   wire = &w;

--- a/src/MPU6050_tockn.h
+++ b/src/MPU6050_tockn.h
@@ -2,7 +2,6 @@
 #define MPU6050_TOCKN_H
 
 #include "Arduino.h"
-#include "Wire.h"
 
 #define MPU6050_ADDR         0x68
 #define MPU6050_SMPLRT_DIV   0x19
@@ -13,6 +12,8 @@
 #define MPU6050_PWR_MGMT_1   0x6b
 #define MPU6050_TEMP_H       0x41
 #define MPU6050_TEMP_L       0x42
+
+class TwoWire;
 
 class MPU6050{
   public:


### PR DESCRIPTION
This fixes an issue that prevents Serial working when Wire.begin() is called with multiple I2C devices connected.