### PR TITLE
configurable i2c address

### DIFF
--- a/src/MPU6050_tockn.cpp
+++ b/src/MPU6050_tockn.cpp
@@ -1,13 +1,15 @@
 #include "MPU6050_tockn.h"
 #include "Arduino.h"
 
-MPU6050::MPU6050(TwoWire &w){
+MPU6050::MPU6050(TwoWire &w, uint8_t i2cAddress):
+                    address(i2cAddress) {
   wire = &w;
   accCoef = 0.02f;
   gyroCoef = 0.98f;
 }
 
-MPU6050::MPU6050(TwoWire &w, float aC, float gC){
+MPU6050::MPU6050(TwoWire &w, float aC, float gC, uint8_t i2cAddress):
+                    address(i2cAddress) {
   wire = &w;
   accCoef = aC;
   gyroCoef = gC;
@@ -28,17 +30,17 @@ void MPU6050::begin(){
 }
 
 void MPU6050::writeMPU6050(byte reg, byte data){
-  wire->beginTransmission(MPU6050_ADDR);
+  wire->beginTransmission(address);
   wire->write(reg);
   wire->write(data);
   wire->endTransmission();
 }
 
 byte MPU6050::readMPU6050(byte reg) {
-  wire->beginTransmission(MPU6050_ADDR);
+  wire->beginTransmission(address);
   wire->write(reg);
   wire->endTransmission(true);
-  wire->requestFrom(MPU6050_ADDR, 1);
+  wire->requestFrom(address, 1);
   byte data =  wire->read();
   return data;
 }
@@ -64,10 +66,10 @@ void MPU6050::calcGyroOffsets(bool console, uint16_t delayBefore, uint16_t delay
     if(console && i % 1000 == 0){
       Serial.print(".");
     }
-    wire->beginTransmission(MPU6050_ADDR);
+    wire->beginTransmission(address);
     wire->write(0x43);
     wire->endTransmission(false);
-    wire->requestFrom((int)MPU6050_ADDR, 6);
+    wire->requestFrom((int)address, 6);
 
     rx = wire->read() << 8 | wire->read();
     ry = wire->read() << 8 | wire->read();
@@ -94,10 +96,10 @@ void MPU6050::calcGyroOffsets(bool console, uint16_t delayBefore, uint16_t delay
 }
 
 void MPU6050::update(){
-	wire->beginTransmission(MPU6050_ADDR);
+	wire->beginTransmission(address);
 	wire->write(0x3B);
 	wire->endTransmission(false);
-	wire->requestFrom((int)MPU6050_ADDR, 14);
+	wire->requestFrom((int)address, 14);
 
   rawAccX = wire->read() << 8 | wire->read();
   rawAccY = wire->read() << 8 | wire->read();

--- a/src/MPU6050_tockn.cpp
+++ b/src/MPU6050_tockn.cpp
@@ -15,25 +15,31 @@ MPU6050::MPU6050(TwoWire &w, float aC, float gC, uint8_t i2cAddress):
   gyroCoef = gC;
 }
 
-void MPU6050::begin(){
-  writeMPU6050(MPU6050_SMPLRT_DIV, 0x00);
-  writeMPU6050(MPU6050_CONFIG, 0x00);
-  writeMPU6050(MPU6050_GYRO_CONFIG, 0x08);
-  writeMPU6050(MPU6050_ACCEL_CONFIG, 0x00);
-  writeMPU6050(MPU6050_PWR_MGMT_1, 0x01);
-  this->update();
+bool MPU6050::begin(){
+  byte result = 0;
+  result |= writeMPU6050(MPU6050_SMPLRT_DIV, 0x00);
+  result |= writeMPU6050(MPU6050_CONFIG, 0x00);
+  result |= writeMPU6050(MPU6050_GYRO_CONFIG, 0x08);
+  result |= writeMPU6050(MPU6050_ACCEL_CONFIG, 0x00);
+  result |= writeMPU6050(MPU6050_PWR_MGMT_1, 0x01);
+  if(result != 0) {
+    return false;
+  }
+
+  update();
   angleGyroX = 0;
   angleGyroY = 0;
   angleX = this->getAccAngleX();
   angleY = this->getAccAngleY();
   preInterval = millis();
+  return true;
 }
 
-void MPU6050::writeMPU6050(byte reg, byte data){
+byte MPU6050::writeMPU6050(byte reg, byte data){
   wire->beginTransmission(address);
   wire->write(reg);
   wire->write(data);
-  wire->endTransmission();
+  return wire->endTransmission();
 }
 
 byte MPU6050::readMPU6050(byte reg) {

--- a/src/MPU6050_tockn.h
+++ b/src/MPU6050_tockn.h
@@ -17,8 +17,8 @@
 class MPU6050{
   public:
 
-  MPU6050(TwoWire &w);
-  MPU6050(TwoWire &w, float aC, float gC);
+  MPU6050(TwoWire &w, uint8_t i2cAddress = MPU6050_ADDR);
+  MPU6050(TwoWire &w, float aC, float gC, uint8_t i2cAddress = MPU6050_ADDR);
 
   void begin();
 
@@ -86,6 +86,8 @@ class MPU6050{
   long preInterval;
 
   float accCoef, gyroCoef;
+
+  uint8_t address;
 };
 
 #endif

--- a/src/MPU6050_tockn.h
+++ b/src/MPU6050_tockn.h
@@ -14,17 +14,24 @@
 #define MPU6050_TEMP_H       0x41
 #define MPU6050_TEMP_L       0x42
 
-class MPU6050{
+class MPU6050 {
   public:
 
   MPU6050(TwoWire &w, uint8_t i2cAddress = MPU6050_ADDR);
   MPU6050(TwoWire &w, float aC, float gC, uint8_t i2cAddress = MPU6050_ADDR);
 
-  void begin();
+  /**
+   * Init the MPU6050, return true if success, otherwise false.
+   */
+  bool begin();
 
   void setGyroOffsets(float x, float y, float z);
 
-  void writeMPU6050(byte reg, byte data);
+  /**
+   * Return the result of the communication. 0 means success.
+   */
+  byte writeMPU6050(byte reg, byte data);
+
   byte readMPU6050(byte reg);
 
   int16_t getRawAccX(){ return rawAccX; };


### PR DESCRIPTION
This commit introduces the possibility to set the i2c from MPU6050 constructor, without touching the library files (not very friendly for many Arduino user). However, full retro compatibility is kept (the default address is 0x68), not need to modify old code.